### PR TITLE
use APK cache if available

### DIFF
--- a/alpine-make-vm-image
+++ b/alpine-make-vm-image
@@ -447,6 +447,11 @@ else
 	dump_alpine_keys etc/apk/keys/
 fi
 
+# use APK cache if available
+if [ -L /etc/apk/cache ]; then
+	ln -s $(realpath /etc/apk/cache) etc/apk/cache
+fi
+
 _apk add --root . --update-cache --initdb alpine-base
 prepare_chroot .
 

--- a/alpine-make-vm-image
+++ b/alpine-make-vm-image
@@ -516,5 +516,9 @@ fi
 #-----------------------------------------------------------------------
 einfo 'Completed'
 
+if [ -L /etc/apk/cache ]; then
+	rm etc/apk/cache > /dev/null 2>&1
+fi
+
 cd - >/dev/null
 ls -lh "$IMAGE_FILE"


### PR DESCRIPTION
If `/etc/apk/cache` exists, use it when creating the VM. This prevents downloading the same packages over and over and lowers network traffic when installing multiple VMs.

It also makes an offline setup possible by using `apk fetch` to preload all required packages.

Verified by:
1. creating a VM
2. `export APK_OPTS="--no-network"`
3. creating another VM without errors