### PR TITLE
Enable CI to pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,6 @@
 name: CI
 on:
+  - pull_request
   - push
 
 jobs:


### PR DESCRIPTION
I noticed that CI does not currently run on pull requests to this PR enables that.

Existing PRs need most probably to be closed and re-enabled after this one is merged to trigger CI on them.