### PR TITLE
Return instead of exit on --version so functions can be used by other scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,3 +22,7 @@ jobs:
               --packages "$(cat example/packages)" \
               --script-chroot \
               alpine-virthardened-$(date +%Y-%m-%d).qcow2 -- ./example/configure.sh
+
+      - name: Test single function
+        run: |
+          sudo bash -c '. ./alpine-make-vm-image --version && get_available_nbd | grep "/dev/nbd"'

--- a/alpine-make-vm-image
+++ b/alpine-make-vm-image
@@ -334,7 +334,7 @@ while [ $# -gt 0 ]; do
 		-t | --serial-console) SERIAL_CONSOLE='yes'; n=1;;
 		-c | --script-chroot) SCRIPT_CHROOT='yes'; n=1;;
 		-h | --help) help 0;;
-		-V | --version) echo "$PROGNAME $VERSION"; exit 0;;
+		-V | --version) echo "$PROGNAME $VERSION"; return;;
 		--) shift; break;;
 	esac
 	shift $n


### PR DESCRIPTION
Alternative for #24 to allow using these functions by other scripts without splitting to multiple files.

This one modifies `--version` switch but I can alternatively also modify it to add new switch if you which.